### PR TITLE
Add emscripten/*.h support

### DIFF
--- a/etc/emscripten.h
+++ b/etc/emscripten.h
@@ -1,1 +1,9 @@
 #include <emscripten.h>
+#include <emscripten/em_asm.h>
+#include <emscripten/fetch.h>
+#include <emscripten/html5.h>
+#include <emscripten/threading.h>
+#include <emscripten/trace.h>
+#include <emscripten/vector.h>
+#include <emscripten/vr.h>
+#include <emscripten/wire.h>

--- a/etc/emscripten.h
+++ b/etc/emscripten.h
@@ -6,4 +6,3 @@
 #include <emscripten/trace.h>
 #include <emscripten/vector.h>
 #include <emscripten/vr.h>
-#include <emscripten/wire.h>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,4 +3,9 @@
 
 extern crate core;
 
+extern "C" {
+    pub fn emscripten_GetProcAddress(name: *const std::os::raw::c_char)
+        -> *const std::os::raw::c_void;
+}
+
 include!(concat!(env!("OUT_DIR"), "/emscripten.rs"));


### PR DESCRIPTION
This PR includes following 2 changes:

1. Fix build failure

In my environment, `cargo build` for some reasons.

First, `.clang_arg` with `-target` and `asmjs-unknown-emscripten` causes following error:

```console
$ RUST_BACKTRACE=full cargo build
   Compiling emscripten-sys v0.1.0 (file:///Users/likr/sandbox/emsys/emscripten-sys)
warning: unused import: `std::process::Command`
 --> build.rs:5:5
  |
5 | use std::process::Command;
  |     ^^^^^^^^^^^^^^^^^^^^^
  |
  = note: #[warn(unused_imports)] on by default

error: failed to run custom build command for `emscripten-sys v0.1.0 (file:///Users/likr/sandbox/emsys/emscripten-sys)`
process didn't exit successfully: `/Users/likr/sandbox/emsys/emscripten-sys/target/debug/build/emscripten-sys-83fe07baf32b7630/build-script-build` (exit code: 101)
--- stderr
thread 'main' panicked at 'TranslationUnit::parse', src/libcore/option.rs:794
stack backtrace:
   0:        0x104758523 - std::sys::imp::backtrace::tracing::imp::unwind_backtrace::hbdeac7eba2f064c6
   1:        0x10475bbed - std::panicking::default_hook::{{closure}}::h9e0a6ca9bb64b479
   2:        0x10475b7b4 - std::panicking::default_hook::h9043ae80af471c9f
   3:        0x10475e2f7 - std::panicking::rust_panic_with_hook::h05996066754c6be9
   4:        0x10475e1e4 - std::panicking::begin_panic::h9fecf34da42eb910
   5:        0x10475e102 - std::panicking::begin_panic_fmt::he5aad713258a67c3
   6:        0x10475e067 - rust_begin_unwind
   7:        0x104785400 - core::panicking::panic_fmt::he26d734b771c5b2c
   8:        0x10478548d - core::option::expect_failed::hce5d6bfc492b4644
   9:        0x103f7c9c0 - <core::option::Option<T>>::expect::h18a732b934e06261
  10:        0x1040d4cd5 - bindgen::ir::context::BindgenContext::new::h768aa69f87b33ee7
  11:        0x104103fc0 - bindgen::Bindings::generate::h882f7c1b45aaa294
  12:        0x10410304f - bindgen::Builder::generate::hbedbd268755561f9
  13:        0x103f42c17 - build_script_build::main::h0637d8f2fcf58c1f
  14:        0x10475dfc5 - std::panicking::try::do_call::h24a2756282b9a31c
  15:        0x10475f28a - __rust_maybe_catch_panic
  16:        0x10475e710 - std::rt::lang_start::hd19f94db0c6a490e
  17:        0x103f432b9 - main
```

Next, `.clang_arg` without `-D__EMSCRIPTEN__` causes following error:

```console
$ RUST_BACKTRACE=full cargo build
   Compiling emscripten-sys v0.1.0 (file:///Users/likr/sandbox/emsys/emscripten-sys)
warning: unused import: `std::process::Command`
 --> build.rs:5:5
  |
5 | use std::process::Command;
  |     ^^^^^^^^^^^^^^^^^^^^^
  |
  = note: #[warn(unused_imports)] on by default

error: failed to run custom build command for `emscripten-sys v0.1.0 (file:///Users/likr/sandbox/emsys/emscripten-sys)`
process didn't exit successfully: `/Users/likr/sandbox/emsys/emscripten-sys/target/debug/build/emscripten-sys-83fe07baf32b7630/build-script-build` (exit code: 101)
--- stdout
/Users/likr/emsdk/emscripten/1.37.9/system/include/SDL/SDL_cpuinfo.h:53:10: fatal error: 'mmintrin.h' file not found, err: true

--- stderr
/Users/likr/emsdk/emscripten/1.37.9/system/include/SDL/SDL_cpuinfo.h:53:10: fatal error: 'mmintrin.h' file not found
thread 'main' panicked at 'failed to generate rust bindings: ()', src/libcore/result.rs:859
stack backtrace:
   0:        0x104a9a5d3 - std::sys::imp::backtrace::tracing::imp::unwind_backtrace::hbdeac7eba2f064c6
   1:        0x104a9dc9d - std::panicking::default_hook::{{closure}}::h9e0a6ca9bb64b479
   2:        0x104a9d864 - std::panicking::default_hook::h9043ae80af471c9f
   3:        0x104aa03a7 - std::panicking::rust_panic_with_hook::h05996066754c6be9
   4:        0x104aa0294 - std::panicking::begin_panic::h9fecf34da42eb910
   5:        0x104aa01b2 - std::panicking::begin_panic_fmt::he5aad713258a67c3
   6:        0x104aa0117 - rust_begin_unwind
   7:        0x104ac74b0 - core::panicking::panic_fmt::he26d734b771c5b2c
   8:        0x104278da3 - core::result::unwrap_failed::h2ddb1983587acf49
   9:        0x10426a4df - <core::result::Result<T, E>>::expect::hfb415c679bc6ea0c
  10:        0x104284d7a - build_script_build::main::h0637d8f2fcf58c1f
  11:        0x104aa0075 - std::panicking::try::do_call::h24a2756282b9a31c
  12:        0x104aa133a - __rust_maybe_catch_panic
  13:        0x104aa07c0 - std::rt::lang_start::hd19f94db0c6a490e
  14:        0x104285369 - main
```

Also, some functions such as `emscripten_set_main_loop` need `-D__EMSCRIPTEN__` for correct implementation.

My environment is as follows:

```console
$ sw_vers
ProductName:	Mac OS X
ProductVersion:	10.12.4
BuildVersion:	16E195

$ rustc --version
rustc 1.18.0-nightly (5c94997b6 2017-03-30)

$ emcc --version
emcc (Emscripten gcc/clang-like replacement) 1.37.9 ()
Copyright (C) 2014 the Emscripten authors (see AUTHORS.txt)
This is free and open source software under the MIT license.
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

$ emcc --cflags
-target asmjs-unknown-emscripten -D__EMSCRIPTEN_major__=1 -D__EMSCRIPTEN_minor__=37 -D__EMSCRIPTEN_tiny__=9 -D_LIBCPP_ABI_VERSION=2 -Werror=implicit-function-declaration -nostdinc -Xclang -nobuiltininc -Xclang -nostdsysteminc -Xclang -isystem/Users/likr/emsdk/emscripten/1.37.9/system/include/libcxx -Xclang -isystem/Users/likr/emsdk/emscripten/1.37.9/system/lib/libcxxabi/include -Xclang -isystem/Users/likr/emsdk/emscripten/1.37.9/system/include/compat -Xclang -isystem/Users/likr/emsdk/emscripten/1.37.9/system/include -Xclang -isystem/Users/likr/emsdk/emscripten/1.37.9/system/include/SSE -Xclang -isystem/Users/likr/emsdk/emscripten/1.37.9/system/include/libc -Xclang -isystem/Users/likr/emsdk/emscripten/1.37.9/system/lib/libc/musl/arch/emscripten -Xclang -isystem/Users/likr/emsdk/emscripten/1.37.9/system/local/include -Xclang -isystem/Users/likr/emsdk/emscripten/1.37.9/system/include/SDL
```

Thus, I modified clang_args.

2. Add emscripten/*.h support

I added emscripten’s sub headers such as html5.h and fetch.h except bind.h and val.h.